### PR TITLE
Updated documentation, marzipan edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Embed Instagram photos.
 
 <p align="center"><img src="instagram-screenshot.png?raw=true" alt="Screenshot"></p>
 
-## How to show a photo
+## How to install an extension
+
+[Download ZIP file](https://github.com/GiovanniSalmeri/yellow-instagram/archive/main.zip) and copy it into your `system/extensions` folder. [Learn more about extensions](https://github.com/annaesvensson/yellow-update).
+
+## How to embed a photo
 
 Create an `[instagram]` shortcut. 
 
@@ -16,9 +20,11 @@ The following arguments are available, all but the first argument are optional:
 `Width` = photo width, pixel or percent  
 `Height` = photo height, pixel or percent  
 
+You should know that the service provider collects personal data and uses cookies.
+
 ## Examples
 
-Showing a photo:
+Embedding a photo:
 
     [instagram BISN9ngjV2-]
     [instagram BISN9ngjV2- light - 500]
@@ -30,11 +36,9 @@ The following settings can be configured in file `system/extensions/yellow-syste
 
 `InstagramStyle` = photo style, e.g. `left`, `center`, `right`  
 
-## Installation
+## Acknowledgements
 
-[Download extension](https://github.com/GiovanniSalmeri/yellow-instagram/archive/main.zip) and copy ZIP file into your `system/extensions` folder. [Learn more about extensions](https://github.com/annaesvensson/yellow-update).
-
-This extension uses [Instagram](https://www.instagram.com). The service provider collects personal data and uses cookies.
+This extension uses [Instagram](https://www.instagram.com). Thank you for the free service.
 
 ## Developer
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ The following settings can be configured in file `system/extensions/yellow-syste
 
 ## Acknowledgements
 
-This extension uses [Instagram](https://www.instagram.com). Thank you for the free service.
+This extension uses [Instagram](https://www.instagram.com) by Meta. Thank you for the free service.
 
 ## Developer
 
-Giovanni Salmeri. [Get help](https://datenstrom.se/yellow/help/)
+Giovanni Salmeri. [Get help](https://datenstrom.se/yellow/help/).


### PR DESCRIPTION
There's a new documentation standard with installation information at the top, as discussed in https://github.com/datenstrom/yellow/discussions/807. Now it should look similar to the Youtube extension.